### PR TITLE
change textarea type from text to mediumtext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Globale Einstellungen - Changelog
 
+## Version 2.7.0
+- update: Textfelder werden jetzt als "mediumtext" angelegt
+
+
 ## Version 2.6.2
 - fixed: Notice-Spalte bei Update hinzufügen #36
 

--- a/_install.sql
+++ b/_install.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS `%TABLE_PREFIX%global_settings_type` (
 
 INSERT INTO %TABLE_PREFIX%global_settings_type VALUES
     (1,  'text', 'text', 0),
-    (2,  'textarea', 'text', 0),
+    (2,  'textarea', 'mediumtext', 0),
     (3,  'select', 'varchar', 255),
     (4,  'radio', 'varchar', 255),
     (5,  'checkbox', 'varchar', 255),

--- a/update.php
+++ b/update.php
@@ -24,7 +24,8 @@ $sql = rex_sql::factory(1);
 $sql->prepareQuery('SELECT name FROM rex_global_settings_field WHERE type_id =:type_id');
 $sql->execute(['type_id' => '2']);
 $results = $sql->getArray();
-
-foreach ($results as $result) {
-    rex_sql_table::get(rex::getTable('global_settings'))->ensureColumn(new rex_sql_column($result['name'], 'mediumtext', true, NULL))->ensure();
+if($results) {
+    foreach ($results as $result) {
+        rex_sql_table::get(rex::getTable('global_settings'))->ensureColumn(new rex_sql_column($result['name'], 'mediumtext', true, NULL))->ensure();
+    }
 }

--- a/update.php
+++ b/update.php
@@ -20,12 +20,14 @@ rex_sql_table::get(rex::getTable('global_settings_field'))
     ->ensure();
 
 //update existing textarea fields from text to mediumtext
-$sql = rex_sql::factory(1);
-$sql->prepareQuery('SELECT name FROM rex_global_settings_field WHERE type_id =:type_id');
-$sql->execute(['type_id' => '2']);
-$results = $sql->getArray();
-if($results) {
-    foreach ($results as $result) {
-        rex_sql_table::get(rex::getTable('global_settings'))->ensureColumn(new rex_sql_column($result['name'], 'mediumtext', true, NULL))->ensure();
+if (rex_addon::get('global_settings')->getProperty('version') <= '2.7.1') {
+    $sql = rex_sql::factory(1);
+    $sql->prepareQuery('SELECT name FROM rex_global_settings_field WHERE type_id =:type_id');
+    $sql->execute(['type_id' => '2']);
+    $results = $sql->getArray();
+    if($results) {
+        foreach ($results as $result) {
+            rex_sql_table::get(rex::getTable('global_settings'))->ensureColumn(new rex_sql_column($result['name'], 'mediumtext', true, NULL))->ensure();
+        }
     }
 }

--- a/update.php
+++ b/update.php
@@ -18,3 +18,13 @@ rex_sql_table::get(rex::getTable('global_settings_field'))
     ->ensureColumn(new rex_sql_column('updatedate', 'datetime'))
     ->ensureIndex(new rex_sql_index('name', ['name'], rex_sql_index::UNIQUE))
     ->ensure();
+
+//update existing textarea fields from text to mediumtext
+$sql = rex_sql::factory(1);
+$sql->prepareQuery('SELECT name FROM rex_global_settings_field WHERE type_id =:type_id');
+$sql->execute(['type_id' => '2']);
+$results = $sql->getArray();
+
+foreach ($results as $result) {
+    rex_sql_table::get(rex::getTable('global_settings'))->ensureColumn(new rex_sql_column($result['name'], 'mediumtext', true, NULL))->ensure();
+}


### PR DESCRIPTION
Beim Install werden Textarea Felder jetzt als mediumtext angelegt. Beim Update werden die Felder einmal aktualisiert.