### PR TITLE
Fix Warning: passing null to file_exists...

### DIFF
--- a/lib/rex_global_settings.php
+++ b/lib/rex_global_settings.php
@@ -52,7 +52,7 @@ class rex_global_settings
 
     public static function deleteCache()
     {
-        if (file_exists(self::$cacheFile)) {
+        if (isset(self::$cacheFile) && file_exists(self::$cacheFile)) {
             return unlink(self::$cacheFile);
         }
 


### PR DESCRIPTION
Deprecated: file_exists(): Passing null to parameter #1 ($filename) of type string is deprecated in src\addons\global_settings\lib\rex_global_settings.php on line 55